### PR TITLE
B40 color framegrabber display

### DIFF
--- a/src/Plugins/CMakeLists.txt
+++ b/src/Plugins/CMakeLists.txt
@@ -33,6 +33,11 @@ if (BUILD_PLUGIN_FRAMEGRABBER)
   add_subdirectory(Plugin_framegrabber)
 endif()
 
+option(BUILD_PLUGIN_PNPFRAMEGRABBER "Build plugin to receive images from the a Plug & Play framegrabber (e.g. using v4l)" OFF)
+if (BUILD_PLUGIN_PNPFRAMEGRABBER)
+  add_subdirectory(Plugin_PnPframegrabber)
+endif()
+
 option(BUILD_PLUGIN_PLANEDETECTION "Build plugin to detect standard planes. Requires python bindings, and pytorch" OFF)
 if (BUILD_PLUGIN_PLANEDETECTION)
   add_subdirectory(Plugin_planeDetection)

--- a/src/Plugins/Plugin_PnPframegrabber/CMakeLists.txt
+++ b/src/Plugins/Plugin_PnPframegrabber/CMakeLists.txt
@@ -19,14 +19,12 @@ find_package(Qt5 REQUIRED X11Extras PrintSupport)
 endif()
 ADD_DEFINITIONS(-DQT_NO_KEYWORDS) # needed because python has something called "slots" and may class with Qt definitions
 
-add_subdirectory(giftgrabapi)
-add_subdirectory(epiphansdk)
 
 file(GLOB SOURCES "*.h" "*.cxx" "*.md")
 
-add_library(Plugin_framegrabber "${PROJECT_BUILD_TYPE}" ${SOURCES})
+add_library(Plugin_PnPframegrabber "${PROJECT_BUILD_TYPE}" ${SOURCES})
 
-target_link_libraries(Plugin_framegrabber
+target_link_libraries(Plugin_PnPframegrabber
   Plugin
   ifind2_common
   Qt5::Widgets
@@ -35,21 +33,21 @@ target_link_libraries(Plugin_framegrabber
   ${Boost_LIBRARIES}
   ${ITK_LIBRARIES}
   ${VTK_LIBRARIES}
-  videograbber
+  #videograbber
   )
 
 
-option(BUILD_STANDALONE_FRAMEGRABBER "Build standalone version of the framegrabber plugin" OFF)
-if (BUILD_STANDALONE_FRAMEGRABBER)
+option(BUILD_STANDALONE_PNPFRAMEGRABBER "Build standalone version of the P&P framegrabber plugin" OFF)
+if (BUILD_STANDALONE_PNPFRAMEGRABBER)
 
     #set_property(SOURCE standalone_framegrabber.cxx PROPERTY SKIP_AUTOMOC ON)
 
-    add_executable(standalone_framegrabber
-      standalone_framegrabber.cxx
-      FGMiniworker.cxx
-      FrameGrabberManager.cxx
+    add_executable(standalone_PnPframegrabber
+      standalone_PnPframegrabber.cxx
+      #FGMiniworker.cxx
+      PnPFrameGrabberManager.cxx
       )
-    target_link_libraries(standalone_framegrabber
+    target_link_libraries(standalone_PnPframegrabber
       Plugin
       Qt5::Widgets
       Qt5::Core # need this for QT signal/slot system
@@ -57,13 +55,13 @@ if (BUILD_STANDALONE_FRAMEGRABBER)
       ${Boost_LIBRARIES}
       ${ITK_LIBRARIES}
       ${VTK_LIBRARIES}
-      videograbber
+      #videograbber
       )
-    set(EXTRA_TARGETS standalone_framegrabber)
+    set(EXTRA_TARGETS standalone_PnPframegrabber)
 
 endif() #BUILD_STANDALONE_FRAMEGRABBER
 
-install(TARGETS Plugin_framegrabber ${EXTRA_TARGETS}
+install(TARGETS Plugin_PnPframegrabber ${EXTRA_TARGETS}
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION pluginlib
   ARCHIVE DESTINATION pluginlib

--- a/src/Plugins/Plugin_PnPframegrabber/Plugin_PnPframegrabber.cxx
+++ b/src/Plugins/Plugin_PnPframegrabber/Plugin_PnPframegrabber.cxx
@@ -1,0 +1,119 @@
+#include "Plugin_PnPframegrabber.h"
+#include <QObject>
+
+Q_DECLARE_METATYPE(ifind::Image::Pointer)
+Plugin_PnPframegrabber::Plugin_PnPframegrabber(QObject *parent) : Plugin(parent)
+{
+    this->mIsInput = true;
+    {
+        ManagerType::Pointer manager_ = ManagerType::New();
+        this->manager = manager_;
+    }
+    {
+        // create widget
+        WidgetType * mWidget_ = new WidgetType;
+        this->mWidget = mWidget_;
+    }
+    {
+        // create image widget
+        ImageWidgetType * mWidget_ = new ImageWidgetType;
+        this->mImageWidget = mWidget_;
+        this->mImageWidget->SetWidgetLocation(ImageWidgetType::WidgetLocation::visible);
+    }
+
+    QObject::connect(this->manager.get(), &ManagerType::ImageGenerated,
+                     this, &Plugin_PnPframegrabber::slot_imageReceived, Qt::DirectConnection);
+
+    this->SetDefaultArguments();
+}
+
+
+void Plugin_PnPframegrabber::Initialize(void){
+    Plugin::Initialize();
+    if (this->mImageWidget != nullptr){
+        reinterpret_cast< ImageWidgetType *>(this->mImageWidget)->Initialize();
+    }
+    std::dynamic_pointer_cast< ManagerType >(this->manager)->Initialize();
+}
+
+void Plugin_PnPframegrabber::SetDefaultArguments(){
+    this->RemoveArgument("stream");
+    this->RemoveArgument("layer");
+    this->RemoveArgument("time");
+    // arguments are defined with: name, placeholder for value, argument type,  description, default value
+    mArguments.push_back({"studioswing", "<val>",
+                          QString( Plugin::ArgumentType[0] ),
+                          "Correct for studio swing (1) or not (0).",
+                          QString::number(std::dynamic_pointer_cast< ManagerType >(this->manager)->params.correct_studio_swing)});
+
+    mArguments.push_back({"resolution", "width.height",
+                          QString( Plugin::ArgumentType[3] ),
+                          "Number of pixels of the video stream, separated by a dot. Accepted values are, in 16:9: 1920.1080, 1360.768, 1280.720; in 4:3: 1600.1200, 1280.960, 1024.786, 800.600, 640.480; and other: 1280.1024, 720.576, 720.480",
+                          std::dynamic_pointer_cast< ManagerType >(this->manager)->params.resolution});
+
+    mArguments.push_back({"pixelsize", "<val>",
+                          QString( Plugin::ArgumentType[2] ),
+                          "Value, in mm, of the pixel size (isotropic).",
+                          QString::number(std::dynamic_pointer_cast< ManagerType >(this->manager)->params.pixel_size[0])});
+
+    mArguments.push_back({"color", "<0/1>",
+                          QString( Plugin::ArgumentType[0] ),
+                          "USe color images (1) or not (0).",
+                          QString::number(std::dynamic_pointer_cast< ManagerType >(this->manager)->params.n_components==3)});
+
+}
+
+void Plugin_PnPframegrabber::SetCommandLineArguments(int argc, char* argv[]){
+    Plugin::SetCommandLineArguments(argc, argv);
+    InputParser input(argc, argv, this->GetCompactPluginName().toLower().toStdString());
+
+    {const std::string &argument = input.getCmdOption("studioswing");
+        if (!argument.empty()){
+            std::dynamic_pointer_cast< ManagerType >(this->manager)->params.correct_studio_swing= atoi(argument.c_str());
+        }}
+    {const std::string &argument = input.getCmdOption("pixelsize");
+        if (!argument.empty()){
+            std::dynamic_pointer_cast< ManagerType >(this->manager)->params.pixel_size[0]= atof(argument.c_str());
+            std::dynamic_pointer_cast< ManagerType >(this->manager)->params.pixel_size[1]= atof(argument.c_str());
+            std::dynamic_pointer_cast< ManagerType >(this->manager)->params.pixel_size[0]= 1.0;
+        }}
+    {const std::string &argument = input.getCmdOption("resolution");
+        if (!argument.empty()){
+            std::dynamic_pointer_cast< ManagerType >(this->manager)->params.resolution= QString(argument.c_str());
+        }}
+    {const std::string &argument = input.getCmdOption("color");
+        if (!argument.empty()){
+            if (atoi(argument.c_str()) == 1){
+                std::dynamic_pointer_cast< ManagerType >(this->manager)->params.n_components = 3;
+            } else {
+                std::dynamic_pointer_cast< ManagerType >(this->manager)->params.n_components = 1;
+            }
+        }}
+    // no need to add above since already in plugin
+    {const std::string &argument = input.getCmdOption("framerate");
+        if (!argument.empty()){
+            std::dynamic_pointer_cast< ManagerType >(this->manager)->params.CaptureFrameRate = atof(argument.c_str());
+        }}
+    {const std::string &argument = input.getCmdOption("verbose");
+        if (!argument.empty()){
+            std::dynamic_pointer_cast< ManagerType >(this->manager)->params.verbose= atoi(argument.c_str());
+        }}
+}
+
+extern "C"
+{
+#ifdef WIN32
+/// Function to return an instance of a new LiveCompoundingFilter object
+__declspec(dllexport) Plugin* construct()
+{
+    return new Plugin_PnPframegrabber();
+}
+#else
+Plugin* construct()
+{
+    return new Plugin_PnPframegrabber();
+}
+#endif // WIN32
+}
+
+

--- a/src/Plugins/Plugin_PnPframegrabber/Plugin_PnPframegrabber.h
+++ b/src/Plugins/Plugin_PnPframegrabber/Plugin_PnPframegrabber.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <Plugin.h>
+#include "PnPFrameGrabberManager.h"
+#include "Widget_PnPframegrabber.h"
+#include <QtVTKVisualization.h>
+
+class Plugin_PnPframegrabber : public Plugin {
+    Q_OBJECT
+
+public:
+
+    typedef PnPFrameGrabberManager ManagerType;
+    typedef Widget_PnPframegrabber WidgetType;
+    typedef QtVTKVisualization ImageWidgetType;
+    Plugin_PnPframegrabber(QObject* parent = 0);
+
+    QString GetPluginName(void){ return "PnP Frame grabber";}
+    QString GetPluginDescription(void) {return "Reads real-time imaging from a video source using a Plug & PLay capture card through V4L / OBS.";}
+
+    void SetCommandLineArguments(int argc, char* argv[]);
+
+    void Initialize(void);
+
+    virtual void SetActivate(bool arg){
+        this->manager->SetActivate(arg);
+    }
+
+protected:
+    virtual void SetDefaultArguments();
+
+};

--- a/src/Plugins/Plugin_PnPframegrabber/PnPFGMiniworker.cxx
+++ b/src/Plugins/Plugin_PnPframegrabber/PnPFGMiniworker.cxx
@@ -1,0 +1,17 @@
+#include <PnPFGMiniworker.h>
+#include <ifindImageWriter.h>
+#include <itkImageFileWriter.h>
+
+void PnPFGMiniworker::doWork(ifind::Image::Pointer im){
+        std::cout<< "[FGMiniworker::doWork()] - image received, save to "<< filename <<std::endl;
+
+        typedef itk::ImageFileWriter<ifind::Image> WriterType;
+
+        /// write the image
+        WriterType::Pointer writer = WriterType::New();
+        writer->SetFileName(filename);
+        writer->SetInput(im);
+        writer->Update();
+
+}
+

--- a/src/Plugins/Plugin_PnPframegrabber/PnPFGMiniworker.h
+++ b/src/Plugins/Plugin_PnPframegrabber/PnPFGMiniworker.h
@@ -1,0 +1,11 @@
+#include <QObject>
+#include <ifindImage.h>
+#include <string>
+
+class PnPFGMiniworker : public QObject{
+    Q_OBJECT
+
+public:
+    Q_SLOT  void doWork(ifind::Image::Pointer im);
+    std::string filename;
+};

--- a/src/Plugins/Plugin_PnPframegrabber/PnPFrameGrabberManager.cxx
+++ b/src/Plugins/Plugin_PnPframegrabber/PnPFrameGrabberManager.cxx
@@ -1,0 +1,140 @@
+#include "PnPFrameGrabberManager.h"
+#include <itkOpenCVImageBridge.h>
+#include <chrono>
+#include <thread>
+#include <boost/filesystem.hpp>
+#include <boost/progress.hpp>
+#include <QTimer>
+#include <chrono>
+#include <itkShiftScaleImageFilter.h>
+#include <QApplication>
+
+PnPFrameGrabberManager::PnPFrameGrabberManager(QObject *parent) : Manager(parent){
+    this->latestAcquisitionTime = std::chrono::steady_clock::now();
+    this->initialAcquisitionTime = std::chrono::steady_clock::now();
+}
+
+int PnPFrameGrabberManager::Initialize(){
+
+
+    this->VideoSource.open(this->params.cam_id,cv::CAP_V4L2);
+    this->VideoSource.set(cv::CAP_PROP_BUFFERSIZE, 1);
+    this->VideoSource.set(cv::CAP_PROP_FOURCC, CV_FOURCC('M', 'J', 'P', 'G'));
+    this->VideoSource.set(cv::CAP_PROP_FPS, this->params.CaptureFrameRate);
+    // convert resolution string into values
+    int w, h;
+    QStringList pieces = this->params.resolution.split( "." );
+    w = pieces.value(0).toInt();
+    h = pieces.value(1).toInt();
+    this->VideoSource.set(cv::CAP_PROP_FRAME_WIDTH, w);
+    this->VideoSource.set(cv::CAP_PROP_FRAME_HEIGHT, h);
+
+
+    if (! this->VideoSource.isOpened()){
+        std::cout << "[ERROR] PnPFrameGrabberManager::Initialize() - Could nt open video grabber on device "<< this->params.cam_id<<std::endl;
+        return -1;
+    }
+
+    if (this->params.verbose){
+        std::cout << "[VERBOSE] PnPFrameGrabberManager::Initialize() - Video settings:"<<std::endl;
+        //        print('fps: {}'.format(fps))
+        //        print('resolution: {}x{}'.format(w,h)) # default 640 x 480
+        //        print('mode: {}'.format(decode_fourcc(fcc))) # default 640 x 480
+        //        print('Buffer size: {}'.format(bs)) # default 640 x 480
+    }
+
+
+    return 0;
+}
+
+
+
+/**
+ * @brief Gets a frame, applies the homography and cropping, and converts it to VTK
+ */
+void PnPFrameGrabberManager::Send(void){
+
+
+    if (this->VideoSource.isOpened()){
+        this->mutex_Frame.lock();
+        try {
+            this->VideoSource >> this->Frame; // get a new frame from camera
+        } catch (const cv::Exception& e) {
+            std::cerr << "[Error] VideoManager::Send() -  reading frame from file. Reason: " << e.msg << std::endl;
+            return;
+        }
+    }
+
+
+    if (this->IsActive())
+    {
+
+        unsigned int wait =0;
+        /*
+        if (this->params.CaptureFrameRate>0){
+            this->params.CaptureFrameRate = (this->params.CaptureFrameRate > 0) && (this->params.CaptureFrameRate < 200)? this->params.CaptureFrameRate : 30;
+            wait = (unsigned int)(1000.0/(float)(this->params.CaptureFrameRate));
+        }
+        */
+        QTimer::singleShot(wait, this, SLOT(Send()));
+
+    } else {
+
+        QApplication::quit();
+    }
+
+    {
+        /// check if the frame is ok
+        if (this->Frame.rows == 0 || this->Frame.cols == 0){
+            std::cerr << "[Error] PnPFrameGrabberManager::Send() -  frame is empty."<< std::endl;
+            this->mutex_Frame.unlock();
+            this->VideoSource.release();
+            QApplication::quit();
+        }
+
+
+        this->mTransmitedFramesCount++;
+        ifind::Image::Pointer image = ifind::Image::New();
+
+        typedef itk::OpenCVImageBridge BridgeType;
+        image->Graft(BridgeType::CVMatToITKImage<ifind::Image>(this->Frame));
+        this->mutex_Frame.unlock();
+
+        /// Add basic meta data
+        {
+            std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
+            double elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now - this->latestAcquisitionTime).count();
+            double currentFrameRate = 1000.0/elapsed_ms;
+            this->latestAcquisitionTime = now;
+            if (currentFrameRate < 0.1){
+                currentFrameRate = this->params.CaptureFrameRate;
+            }
+
+            // measure time from beginnning
+            double milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(now - this->initialAcquisitionTime).count();
+            int hours = milliseconds/1000/3600;
+            int minutes = (milliseconds/1000 -hours*3600)/60;
+            float seconds = milliseconds/1000.0 -hours*3600 - minutes*60;
+            QString timestring;
+            timestring.sprintf("%02d:%02d:%02.3f", hours, minutes, seconds);
+
+            image->SetMetaData<std::string>("StreamTime", timestring.toStdString());
+
+            std::string timestamp = std::to_string(std::chrono::duration_cast< std::chrono::milliseconds >(std::chrono::system_clock::now().time_since_epoch()).count());
+
+            image->SetMetaData<std::string>("DNLTimestamp", timestamp);
+            image->SetMetaData<std::string>("AcquisitionSystem", "FrameGrabber");
+            image->SetMetaData<std::string>("NDimensions", "2");
+            image->SetMetaData<std::string>("ImageMode", std::to_string(ifind::Image::ImageMode::External));
+            image->SetMetaData<>("AcquisitionFrameRate", QString::number(currentFrameRate).toStdString());
+            image->SetMetaData<>("TransmissionFrameRate", QString::number(this->params.CaptureFrameRate).toStdString());
+            image->SetMetaData<>("TransmitedFrameCount", QString::number(this->mTransmitedFramesCount).toStdString());
+        }
+        image->SetSpacing(params.pixel_size);
+        if (this->mTransmitedStreamType.size()>0){
+            image->SetStreamType(this->mTransmitedStreamType);
+        }
+        Q_EMIT this->ImageGenerated(image);
+    }
+}
+

--- a/src/Plugins/Plugin_PnPframegrabber/PnPFrameGrabberManager.h
+++ b/src/Plugins/Plugin_PnPframegrabber/PnPFrameGrabberManager.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <Manager.h>
+#include <string>
+#include <memory>
+#include <ifindImage.h>
+#include <vector>
+#include <list>
+#include <chrono>
+#include <opencv2/opencv.hpp>
+
+
+class PnPFrameGrabberManager : public Manager{
+    Q_OBJECT
+
+public:
+    typedef PnPFrameGrabberManager            Self;
+    typedef std::shared_ptr<Self>       Pointer;
+
+    /** Constructor */
+    static Pointer New(QObject *parent = 0) {
+        return Pointer(new PnPFrameGrabberManager(parent));
+    }
+
+    int Initialize();
+
+    struct Parameters {
+        Parameters() {
+
+            pixel_size[0] = 1;
+            pixel_size[1] = 1;
+            pixel_size[2] = 1;
+
+            cam_id = 4;
+            resolution = "1280.720"; // width.height
+            //Resolution_factor = 1.0;
+            CaptureFrameRate  = 30;
+            n_components = 1;
+
+            verbose = false;
+            correct_studio_swing = false;
+        }
+
+        double pixel_size[3];
+        QString resolution;
+        int cam_id;
+        //float Resolution_factor;
+        double CaptureFrameRate;
+        bool verbose;
+        bool correct_studio_swing;
+        /**
+         * @brief number of components of raw data: 1 (gray) or 3 YUV
+         */
+        int n_components;
+    };
+
+    Parameters params;
+
+public Q_SLOTS:
+
+    /**
+   * @brief Send the latest dnl::Image signal
+   *
+   * This method has to be public so that it can be binded to the periodic callback
+   */
+    virtual void Send(void);
+
+protected:
+    PnPFrameGrabberManager(QObject *parent = 0);
+
+private:
+
+    cv::VideoCapture VideoSource;
+
+    std::mutex mutex_frame_buffer;
+    std::mutex mutex_Frame;
+    cv::Mat Frame;
+    std::chrono::steady_clock::time_point latestAcquisitionTime;
+    std::chrono::steady_clock::time_point initialAcquisitionTime;
+
+};

--- a/src/Plugins/Plugin_PnPframegrabber/README.md
+++ b/src/Plugins/Plugin_PnPframegrabber/README.md
@@ -1,0 +1,37 @@
+# Plug & Play Framegrabber plugin.
+
+A plug-in to read real time images using a plug and play framegrabber that supports V4L2.
+
+## Usage
+
+
+WIP------------
+
+The following plug-in options can be tweaked via the command line interface:
+
+``` bash
+# PLUGIN PnP Frame grabber
+   Reads real-time imaging from a video source using a Plug & PLay capture card through V4L / OBS.
+        --pnpframegrabber_framerate <val> [ type: FLOAT]	Frame rate at which the plugin does the work. (Default: 20) 
+        --pnpframegrabber_verbose <val> [ type: BOOL]	Whether to print debug information (1) or not (0). (Default: 0) 
+        --pnpframegrabber_showimage <val> [ type: INT]	Whether to display realtime image outputs in the central window (1) or not (0). 
+                                                        (Default: <1 for input plugins, 0 for the rest>) 
+        --pnpframegrabber_showwidget <val> [ type: INT]	Whether to display widget with plugin information (1-4) or not (0). Location is 
+                                                                1- top left, 2- top right, 3-bottom left, 4-bottom right. (Default: visible, 
+                                                                default location depends on widget.) 
+   Plugin-specific arguments:
+        --pnpframegrabber_studioswing <val> [ type: BOOL]	Correct for studio swing (1) or not (0). (Default: 0) 
+        --pnpframegrabber_resolution width.height [ type: STRING]	Number of pixels of the video stream, separated by a dot. Accepted values are, 
+                                                                        in 16:9: 1920.1080, 1360.768, 1280.720; in 4:3: 1600.1200, 1280.960, 1024.786, 
+                                                                        800.600, 640.480; and other: 1280.1024, 720.576, 720.480 (Default: 1280.720) 
+        --pnpframegrabber_pixelsize <val> [ type: FLOAT]	Value, in mm, of the pixel size (isotropic). (Default: 1) 
+        --pnpframegrabber_color <0/1> [ type: BOOL]	USe color images (1) or not (0). (Default: 0) 
+
+```
+
+
+# Build and configuration
+
+This plug-in requires opencv. In Linux it requires the V4L2 libraries (vidoe for linux) installed, otherwise it is just plug and play.
+The framegrabber can be tested in advance with OBS or VLC players to check that it is correctly recognised by the system.
+

--- a/src/Plugins/Plugin_PnPframegrabber/Widget_PnPframegrabber.cxx
+++ b/src/Plugins/Plugin_PnPframegrabber/Widget_PnPframegrabber.cxx
@@ -1,0 +1,42 @@
+#include "Widget_PnPframegrabber.h"
+
+#include <QLabel>
+#include <QVBoxLayout>
+
+Widget_PnPframegrabber::Widget_PnPframegrabber(
+    QWidget *parent, Qt::WindowFlags f)
+    : QtPluginWidgetBase(parent, f)
+{
+
+    this->mWidgetLocation = WidgetLocation::top_left;
+    mStreamTypes = ifind::InitialiseStreamTypeSetFromString("Input");
+
+    mLabel = new QLabel("Text not set", this);
+    mLabel->setStyleSheet(QtPluginWidgetBase::sQLabelStyle);
+
+    auto labelFont = mLabel->font();
+    labelFont.setPixelSize(15);
+    labelFont.setBold(true);
+    mLabel->setFont(labelFont);
+
+    auto vLayout = new QVBoxLayout(this);
+    vLayout->setContentsMargins(0, 0, 0, 0);
+    vLayout->setSpacing(0);
+    this->setLayout(vLayout);
+
+    vLayout->addWidget(mLabel);
+    this->AddImageViewCheckboxToLayout(vLayout);
+}
+
+void Widget_PnPframegrabber::SendImageToWidgetImpl(ifind::Image::Pointer image){
+
+    std::stringstream stream;
+    stream << "==" << this->mPluginName.toStdString() << "=="<< std::endl;
+    stream << "Sending " << ifind::StreamTypeSetToString(this->mStreamTypes) << std::endl;
+
+    if (image->HasKey("StreamTime")){
+        stream << "Stream time: "<<image->GetMetaData<std::string>("StreamTime") << std::endl;
+    }
+
+    mLabel->setText(stream.str().c_str());
+}

--- a/src/Plugins/Plugin_PnPframegrabber/Widget_PnPframegrabber.h
+++ b/src/Plugins/Plugin_PnPframegrabber/Widget_PnPframegrabber.h
@@ -1,0 +1,21 @@
+#pragma once
+#include <QWidget>
+#include <ifindImage.h>
+#include <QtPluginWidgetBase.h>
+
+class QLabel;
+
+class Widget_PnPframegrabber : public QtPluginWidgetBase
+{
+    Q_OBJECT
+
+public:
+    Widget_PnPframegrabber(QWidget *parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
+
+    virtual void SendImageToWidgetImpl(ifind::Image::Pointer image);
+
+private:
+    // raw pointer to new object which will be deleted by QT hierarchy
+    QLabel *mLabel;
+
+};

--- a/src/Plugins/Plugin_PnPframegrabber/standalone_PnPframegrabber.cxx
+++ b/src/Plugins/Plugin_PnPframegrabber/standalone_PnPframegrabber.cxx
@@ -1,0 +1,71 @@
+#include <PnPFrameGrabberManager.h>
+//#include <Plugin_framegrabber.h>
+#include <QThread>
+#include <ifindImage.h>
+#include <QObject>
+#include <PnPFGMiniworker.h>
+
+
+std::string filename("/tmp/image.mhd");
+
+void Usage(void){
+    std::cout << std::endl;
+    std::cout << "# Standalone frame grabber "<<std::endl;
+    std::cout <<"\t"<< "Reads images from a Epiphan DVI2USB 3.0 framegrabber."<<std::endl;
+    std::cout <<"\t"<< "Additional arguments:"<<std::endl;
+    //std::cout <<"\t"<<"\t-fg_resolution <multiplicative factor >\tFactor to multiply the default capture resolution of  1920×1080  (HD). Default: 1"<<std::endl;
+    std::cout <<"\t"<<"\t-fg_framerate <capture frame rate >\tFrame rate of the capture for the frame grabber. If <=0, then maximum framerate is used.  "<<std::endl;
+    std::cout <<"\t"<<"\t-fg_pixelsize <px py>\tPixel size, in mm "<<std::endl;
+    std::cout <<"\t"<<"\t-fg_filename <fn>\tName of the image to be saved, default "<< filename <<std::endl;
+    std::cout <<"\t"<<"\t-fg_ncomponents <fn>\t1 (grayscale) or 3 (YUV)"<<std::endl;
+}
+
+
+int main(int argc, char *argv[])
+{
+
+    PnPFrameGrabberManager::Pointer fgm = PnPFrameGrabberManager::New();
+
+    /// Read arguments
+    /*
+    int i = 1;
+    while (i < argc)
+    {
+        if (!strcmp(argv[i], "-fg_resolution"))
+        {
+            fgm->params.Resolution_factor =atof(argv[++i]);
+        } else  if (!strcmp(argv[i], "-fg_framerate"))
+        {
+            fgm->params.CaptureFrameRate = atof(argv[++i]);
+        }
+        else  if (!strcmp(argv[i], "-fg_pixelsize"))
+        {
+            fgm->params.pixel_size[0] = atof(argv[++i]);
+            fgm->params.pixel_size[1] = atof(argv[++i]);
+            fgm->params.pixel_size[2] = 1;
+        }   else  if (!strcmp(argv[i], "-fg_filename"))
+        {
+            filename = argv[++i];
+        }   else  if (!strcmp(argv[i], "-fg_ncomponents"))
+        {
+            fgm->params.n_components = atoi(argv[++i]);
+        }
+        i++;
+    }
+    */
+
+    /// Set up a miniworker
+    PnPFGMiniworker* miniworker = new PnPFGMiniworker();
+    miniworker->filename = filename;
+    QObject::connect(fgm.get(),SIGNAL(ImageGenerated(ifind::Image::Pointer)), miniworker, SLOT(doWork(ifind::Image::Pointer)));
+    /// Set up the video grabber
+
+    fgm->params.verbose = true;
+    fgm->Initialize();
+    fgm->SetActivate(true); // will trigger 1 frame
+
+    delete(miniworker);
+
+
+    return 0;
+}

--- a/src/Plugins/Plugin_framegrabber/FrameGrabberManager.cxx
+++ b/src/Plugins/Plugin_framegrabber/FrameGrabberManager.cxx
@@ -18,10 +18,6 @@ FrameGrabberManager::FrameGrabberManager(QObject *parent) : Manager(parent){
     this->Cap = nullptr;
     this->latestAcquisitionTime = std::chrono::steady_clock::now();
     this->initialAcquisitionTime = std::chrono::steady_clock::now();
-    std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
-    double elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now - this->latestAcquisitionTime).count();
-    double currentFrameRate = 1000.0/elapsed_ms;
-
 }
 
 int FrameGrabberManager::Initialize(){

--- a/src/Plugins/Plugin_framegrabber/FrameGrabberManager.cxx
+++ b/src/Plugins/Plugin_framegrabber/FrameGrabberManager.cxx
@@ -205,10 +205,9 @@ std::vector<ifind::Image::Pointer> FrameGrabberManager::getFrameAsIfindImageData
     Y->DisconnectPipeline();
     YUV[0] = Y;
 
-    buffer_idx+=numberOfPixels;
-
     /// now get the U and V components
     if (params.n_components ==3) {
+        buffer_idx+=numberOfPixels;
         // No longer ensuring integrity here - buffer not copied
         ImportFilterType::Pointer importFilter = ImportFilterType::New();
 

--- a/src/Plugins/Plugin_framegrabber/Plugin_framegrabber.cxx
+++ b/src/Plugins/Plugin_framegrabber/Plugin_framegrabber.cxx
@@ -51,6 +51,11 @@ void Plugin_framegrabber::SetDefaultArguments(){
                           "Value, in mm, of the pixel size (isotropic).",
                           QString::number(std::dynamic_pointer_cast< ManagerType >(this->manager)->params.pixel_size[0])});
 
+    mArguments.push_back({"color", "<0/1>",
+                          QString( Plugin::ArgumentType[0] ),
+                          "USe color images (1) or not (0).",
+                          QString::number(std::dynamic_pointer_cast< ManagerType >(this->manager)->params.n_components==3)});
+
 }
 
 void Plugin_framegrabber::SetCommandLineArguments(int argc, char* argv[]){
@@ -66,6 +71,15 @@ void Plugin_framegrabber::SetCommandLineArguments(int argc, char* argv[]){
             std::dynamic_pointer_cast< ManagerType >(this->manager)->params.pixel_size[0]= atof(argument.c_str());
             std::dynamic_pointer_cast< ManagerType >(this->manager)->params.pixel_size[1]= atof(argument.c_str());
             std::dynamic_pointer_cast< ManagerType >(this->manager)->params.pixel_size[0]= 1.0;
+        }}
+    {const std::string &argument = input.getCmdOption("color");
+        if (!argument.empty()){
+            if (atoi(argument.c_str()) == 1){
+                std::dynamic_pointer_cast< ManagerType >(this->manager)->params.n_components = 3;
+            } else {
+                std::dynamic_pointer_cast< ManagerType >(this->manager)->params.n_components = 1;
+            }
+
         }}
     // no need to add above since already in plugin
     {const std::string &argument = input.getCmdOption("framerate");


### PR DESCRIPTION
Fixes #40 

### Description
Issue 40 was a problem with colour and image from the frame grabber. Epiphan DVI2USB framegrabber stoped support for linux and mac so we are stuck on an older kernel version. As a result, we decided to broaden support to other framegrabbers that do not have proprietary drivers, and instead use v4l / OBS. These are often much more affordable too.

To address this we created a new plug-in to support plug and play framegrabbers.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


### Checklist

- [x] I have read the [`CONTRIBUTING`](https://github.com/gomezalberto/pretus/blob/main/docs/CONTRIBUTING.md) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] My code is properly tested
- [ ] My code follows the style guidelines 
- [x] My code does not contain unused elements. If so, I documented why it needs to.
- [ ] My changes generate no new warnings 
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] This pull request is ready to be reviewed
- [x] My branch is up-to-date with master (with use of rebase if needed) 
- [ ] If the PR is ready and there are multiple commits, I have [squashed them and force-pushed](https://www.w3docs.com/snippets/git/how-to-combine-multiple-commits-into-one-with-3-steps.html#force-pushing-commits-7)


