### PR TITLE
issue #60: added subfolder and save one capabilities in imagefilewriter

### DIFF
--- a/src/PluginLib/QtPluginWidgetBase.cxx
+++ b/src/PluginLib/QtPluginWidgetBase.cxx
@@ -3,6 +3,7 @@
 #include <QComboBox>
 #include <QHBoxLayout>
 #include <QLabel>
+#include <QLineEdit>
 
 static const std::string sDefaultStreamTypesStr("Input");
 const QString QtPluginWidgetBase::sQSliderStyle = "QSlider::groove:horizontal { background-color: none; border: 1px solid #828282;  height: 2px;  border-radius: 2px; }"
@@ -25,6 +26,9 @@ const QString QtPluginWidgetBase::sQPushButtonStyle = "QPushButton { border: 2px
 
 const QString QtPluginWidgetBase::sQGroupBoxStyle = "QGroupBox { border: 1px solid white; background-color : black; color : white; } "
         "QGroupBox::title {subcontrol-origin: margin; subcontrol-position: top center; top: -4px; color: #000000; background-color: rgb(255, 255, 255);}";
+
+
+const QString QtPluginWidgetBase::sQLineEditStyle  = "QLineEdit { background-color : black; color : white; }";
 
 QtPluginWidgetBase::QtPluginWidgetBase(
     QWidget *parent, Qt::WindowFlags f)

--- a/src/PluginLib/QtPluginWidgetBase.h
+++ b/src/PluginLib/QtPluginWidgetBase.h
@@ -20,6 +20,7 @@ public:
     static const QString sQLabelStyle;
     static const QString sQPushButtonStyle;
     static const QString sQGroupBoxStyle;
+    static const QString sQLineEditStyle;
 
     enum class WidgetLocation  { visible, visible_overlay, hidden, // for images
                                top_left, top_right, bottom_left, bottom_right, overlaid}; // for other widgets

--- a/src/Plugins/Plugin_imageFileWriter/Plugin_imageFileWriter.h
+++ b/src/Plugins/Plugin_imageFileWriter/Plugin_imageFileWriter.h
@@ -48,11 +48,16 @@ public Q_SLOTS:
 
     virtual void slot_toggleSaveImages(bool b);
 
+    virtual void slot_saveOneImage();
+
+    virtual void slot_setSubFolder();
+
     virtual void slot_Write(ifind::Image::Pointer arg);
 
 Q_SIGNALS:
 
     void ImageToBeSaved(ifind::Image::Pointer image);
+    void ImageActuallyWritten();
 
 protected:
     virtual void SetDefaultArguments();
@@ -75,5 +80,7 @@ private:
     std::mutex m_Mutex;
 
     bool mSaveImages;
+    bool mSaveOne;
     bool mVerbose;
+    QString mSubfolder;
 };

--- a/src/Plugins/Plugin_imageFileWriter/Widget_imageFileWriter.h
+++ b/src/Plugins/Plugin_imageFileWriter/Widget_imageFileWriter.h
@@ -5,7 +5,9 @@
 #include <ifindStreamTypeHelper.h>
 
 class QCheckBox;
+class QPushButton;
 class QLabel;
+class QLineEdit;
 
 class Widget_imageFileWriter : public QtPluginWidgetBase
 {
@@ -17,6 +19,10 @@ public:
     virtual void SendImageToWidgetImpl(ifind::Image::Pointer image);
 
     QCheckBox *mCheckBoxSaveFiles;
+    QPushButton *mPushButtonSaveOne;
+    QLineEdit *mSubfolderText;
+
+    void setOutputFolder(const QString &outputFolder);
 
 public Q_SLOTS:
 
@@ -26,6 +32,6 @@ public Q_SLOTS:
 private:
     // raw pointer to new object which will be deleted by QT hierarchy
     QLabel *mLabel;
-
+    QString mOutputFolder;
     int n_images_written;
 };


### PR DESCRIPTION
Fixes #60.

### Description
Added features to save one image and to select a custom subfolder for all streams.


## Type of change
Please delete options accordingly to the description.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


